### PR TITLE
Build script fix: set working dir for build, use "dotnet run" for test.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,4 @@
 image: Visual Studio 2017
 build_script:
-  - ps: .\build.cmd
+  - cmd: .\build.cmd
+test: off

--- a/build.fsx
+++ b/build.fsx
@@ -69,9 +69,10 @@ let resetVersion _ = srcProjects |> Seq.iter (pokeVersion version.NuGetVersion "
 let build _ = DotNetCli.Build (fun c -> 
   { c with 
       ToolPath = dotnetCliPath
-      Configuration = "debug" } )
+      Configuration = "debug" 
+      WorkingDir = "src"} )
 
-let test _ = testProjects |> Seq.map (sprintf "test \"%s\" --no-build") |> Seq.iter runDotNet
+let test _ = testProjects |> Seq.map (sprintf "run -p \"%s\"") |> Seq.iter runDotNet
 
 // Build target definitions
 


### PR DESCRIPTION
Using "dotnet run" for Expecto tests for now, I wasn't able to get Expecto test adapter to work.