### PR TITLE
Reordering project file

### DIFF
--- a/src/Mechanic.CommandLine/Program.fs
+++ b/src/Mechanic.CommandLine/Program.fs
@@ -11,10 +11,10 @@ let main argv =
         p |> ProjectFile.getSourceFiles
         |> SymbolGraph.solveOrder (fun f -> f.FullName)
         |> function
-            |TopologicalOrderResult.TopologicalOrder xs ->
+            | TopologicalOrderResult.TopologicalOrder xs ->
                 xs |> fun x -> ProjectFile.updateProjectFile x p 
-                TopologicalOrderResult.TopologicalOrder xs
-            |x -> x
+                TopologicalOrderResult.TopologicalOrder (xs |> List.map (fun f -> f.FullName))
+            | TopologicalOrderResult.Cycle xs -> TopologicalOrderResult.Cycle (xs |> List.map (fun f -> f.FullName))
         |> printfn "%A"
     | 2 ->
         let root = argv.[0]

--- a/src/Mechanic.CommandLine/Program.fs
+++ b/src/Mechanic.CommandLine/Program.fs
@@ -1,9 +1,19 @@
 ﻿open Mechanic
+open Mechanic.Files
 
 [<EntryPoint>]
 let main argv =
-    let root = argv.[0]
-    let pattern = argv.[1]
-    SymbolGraph.solveOrderFromPattern root pattern 
-    |> printfn "%A"
+    match argv.Length with
+    | 1 ->
+        ProjectFile.loadFromFile argv.[0]
+        |> ProjectFile.getSourceFiles
+        |> List.map (fun f -> f.FullName)
+        |> List.filter (fun x -> x.EndsWith ".fs")
+        |> SymbolGraph.solveOrder
+        |> printfn "%A"
+    | 2 ->
+        let root = argv.[0]
+        let pattern = argv.[1]
+        SymbolGraph.solveOrderFromPattern root pattern 
+        |> printfn "%A"
     0

--- a/src/Mechanic.CommandLine/Program.fs
+++ b/src/Mechanic.CommandLine/Program.fs
@@ -8,7 +8,6 @@ let main argv =
         ProjectFile.loadFromFile argv.[0]
         |> ProjectFile.getSourceFiles
         |> List.map (fun f -> f.FullName)
-        |> List.filter (fun x -> x.EndsWith ".fs")
         |> SymbolGraph.solveOrder
         |> printfn "%A"
     | 2 ->

--- a/src/Mechanic.CommandLine/Program.fs
+++ b/src/Mechanic.CommandLine/Program.fs
@@ -1,14 +1,20 @@
 ﻿open Mechanic
 open Mechanic.Files
+open Mechanic.GraphAlg
+open Mechanic.Utils
 
 [<EntryPoint>]
 let main argv =
     match argv.Length with
     | 1 ->
-        ProjectFile.loadFromFile argv.[0]
-        |> ProjectFile.getSourceFiles
-        |> List.map (fun f -> f.FullName)
-        |> SymbolGraph.solveOrder
+        let p = ProjectFile.loadFromFile argv.[0]
+        p |> ProjectFile.getSourceFiles
+        |> SymbolGraph.solveOrder (fun f -> f.FullName)
+        |> function
+            |TopologicalOrderResult.TopologicalOrder xs ->
+                xs |> fun x -> ProjectFile.updateProjectFile x p 
+                TopologicalOrderResult.TopologicalOrder xs
+            |x -> x
         |> printfn "%A"
     | 2 ->
         let root = argv.[0]

--- a/src/Mechanic.Tests/FileOrderTests.fs
+++ b/src/Mechanic.Tests/FileOrderTests.fs
@@ -31,11 +31,11 @@ let makeTempProject sources =
 
 let expectOrder sources =
     let (_, _, files) = makeTempProject sources
-    Expect.equal (SymbolGraph.solveOrder files) (TopologicalOrder files) "Wrong order of files"
+    Expect.equal (SymbolGraph.solveOrder id files) (TopologicalOrder files) "Wrong order of files"
 
 let checkCycle sources =
     let (_, _, files) = makeTempProject sources
-    match SymbolGraph.solveOrder files with
+    match SymbolGraph.solveOrder id files with
     | Cycle _ -> true
     | _ -> false
 

--- a/src/Mechanic.Tests/Files.fs
+++ b/src/Mechanic.Tests/Files.fs
@@ -41,6 +41,15 @@ let makeTempProjFile contents =
             File.Delete(pFile)            
             Expect.equal sfNames ["File1.fs"; "File2.fs"; "File3.fs"] "File names are correct"
 
+         testCase "Source files full path are parsed correctly" <| fun _ ->
+            let pFile = makeTempProjFile projectFileText
+            let pDir = FileInfo(pFile).Directory.FullName
+            let pf = ProjectFile.loadFromFile pFile
+            let sfNames = ProjectFile.getSourceFiles pf |> List.map (fun x -> x.FullName)
+            File.Delete(pFile)
+            let expectedPaths = ["File1.fs"; "File2.fs"; "File3.fs"] |> List.map (fun x -> Path.Combine(pDir, x))        
+            Expect.equal sfNames expectedPaths "File paths are correct"
+
          testCase "Source file order is persisted to disk correctly" <| fun _ ->
             let pFile = makeTempProjFile projectFileText
             let pf = ProjectFile.loadFromFile pFile

--- a/src/Mechanic/Files.fs
+++ b/src/Mechanic/Files.fs
@@ -89,7 +89,6 @@ module ProjectFile =
             match files with
             | [] -> parent
             | x::xs ->
-                //makeCompileNode x.ShortName doc
                 x.XmlNode |> parent.AppendChild |> ignore
                 addCompileNodes xs parent doc
 

--- a/src/Mechanic/Files.fs
+++ b/src/Mechanic/Files.fs
@@ -13,7 +13,7 @@ type ProjectFile = {
 type SourceFile = {
     FullName : string
     ShortName : string
-    Xml : XmlNode
+    XmlNode : XmlNode
 }
 
 
@@ -75,7 +75,7 @@ module ProjectFile =
             let fi = FileInfo (Path.Combine(projectDir, x))
             { FullName  = fi.FullName
               ShortName = x 
-              Xml = xml})
+              XmlNode = xml})
 
     let makeNode tag (doc:XmlDocument) =
         doc.CreateElement tag
@@ -90,7 +90,7 @@ module ProjectFile =
             | [] -> parent
             | x::xs ->
                 //makeCompileNode x.ShortName doc
-                x.Xml |> parent.AppendChild |> ignore
+                x.XmlNode |> parent.AppendChild |> ignore
                 addCompileNodes xs parent doc
 
         let addNewItemGroup (sFiles:SourceFile list) (pf:ProjectFile) =

--- a/src/Mechanic/Files.fs
+++ b/src/Mechanic/Files.fs
@@ -68,9 +68,10 @@ module ProjectFile =
         |> List.ofSeq
 
     let getSourceFiles (pf:ProjectFile) =
+        let projectDir = FileInfo(pf.FileName).Directory.FullName
         parseSourceFileNames pf.ProjectNode
         |> List.map (fun x ->
-            let fi = FileInfo x
+            let fi = FileInfo (Path.Combine(projectDir, x))
             { FullName  = fi.FullName
               ShortName = x })
 

--- a/src/Mechanic/SymbolGraph.fs
+++ b/src/Mechanic/SymbolGraph.fs
@@ -5,7 +5,7 @@ open Mechanic.Utils
 open Mechanic.GraphAlg
 
 let getDependencies files =
-    let depsData = files |> List.map (fun (f: string) -> if f.EndsWith ".fs" then SymbolGetter.getSymbols f else f, [], [], [])
+    let depsData = files |> List.map (fun (f: string) -> if f.EndsWith ".fs" then SymbolGetter.getSymbols f else f, [], [])
     let allDefsMap = 
         depsData |> Seq.collect (fun (f,defs,_) -> defs |> List.map (fun d -> lastPart d, (d, f)))
         |> Seq.groupBy fst |> Seq.map (fun (k, xs) -> k, xs |> Seq.map snd |> Seq.toList) |> Map.ofSeq

--- a/src/Mechanic/SymbolGraph.fs
+++ b/src/Mechanic/SymbolGraph.fs
@@ -56,15 +56,17 @@ let getDependencies files =
     //printfn "%A" deps
     deps
 
-let solveOrder files =
+let solveOrder fileNameSelector xs =
+    let filesMap = xs |> Seq.map (fun x -> fileNameSelector x, x) |> Map.ofSeq
+    let files = xs |> List.map fileNameSelector
     let deps = getDependencies files
     let edges = deps |> List.map (fun (f1,f2,_) -> f1, f2)
     match GraphAlg.topologicalOrder files edges with
     | TopologicalOrderResult.Cycle xs ->
         printfn "Cycle with %A" (deps |> List.filter (fun (x,y,_) -> List.contains x xs && List.contains y xs))
-        TopologicalOrderResult.Cycle xs
-    | x-> x
+        TopologicalOrderResult.Cycle (xs |> List.map (fun x -> filesMap.[x]))
+    | TopologicalOrderResult.TopologicalOrder xs -> TopologicalOrderResult.TopologicalOrder (xs |> List.map (fun x -> filesMap.[x]))
 
 let solveOrderFromPattern root filePattern =
     Directory.EnumerateFiles(root,filePattern) |> Seq.toList
-    |> solveOrder
+    |> solveOrder id

--- a/src/Mechanic/SymbolGraph.fs
+++ b/src/Mechanic/SymbolGraph.fs
@@ -3,7 +3,7 @@ open System.IO
 open Utils.Namespace
 
 let getDependencies files =
-    let depsData = files |> List.map SymbolGetter.getSymbols
+    let depsData = files |> List.map (fun (f: string) -> if f.EndsWith ".fs" then SymbolGetter.getSymbols f else f, [], [], [])
     let allDefsMap = 
         depsData |> Seq.collect (fun (f,defs,_,_) -> defs |> List.map (fun d -> lastPart d, (d, f)))
         |> Seq.groupBy fst |> Seq.map (fun (k, xs) -> k, xs |> Seq.map snd |> Seq.toList) |> Map.ofSeq


### PR DESCRIPTION
This allows us to use Mechanic on project file.

* when calling CLI with one argument, it is expected to be `.fsproj`, and it will be overwritten with new order
*  `SymbolGraph.solveOrder` works with generic type with selector for filename
* In project handling, `XmlNode` of items is saved, and then used for reordering
* `SymbolGraph.solveOrder` support files other than `.fs`, its treated as file without dependencies

There seems to be a problem with island nodes (files without dependencies) in ordering, I fix that in separate PR.

This don't support msbuild properties mentioned in #61 and #62.
