### PR TITLE
Fix topological order alg tests, improve min-edit distance heuristic.

### DIFF
--- a/OrderingAlg.md
+++ b/OrderingAlg.md
@@ -38,13 +38,6 @@ Actual implementation uses Map with the last part of the qualified identifier of
 Correct ordering of files is such that for each dependency `file1 -> file2`, `file1` is before `file2`.
 This directly translates to Topological order problem in oriented graphs: https://en.wikipedia.org/wiki/Topological_sort
 
-Kahn's algorithm mentioned on wiki is implemented with modifications to find ordering with minimal number of move operations:
+Kahn's algorithm mentioned on wiki is implemented with modifications to find ordering close to minimal number of *move up/down* operations (switching order of two neighbour elements):
 
-In each cycle, we add only one node to resulting ordered list; from set of nodes with no incoming edge, we select the one that comes first in original order.
-
-This alg outputs ordering that can be achieved by minimal number of *move up/down* operations (switching order of two neighbour elements).
-
-> *Side note (by @jindraivanek)*: If we choose different definition for edit distance as *sum of differences in node positions*, 
-> then above alg wouldn't work, and from my experiments with it, I think this is a hard (NP-complete) problem.
-
-Later, we need to find a way how to find ordering with minimal editing distance from original ordering.
+In each cycle, we add only one node to resulting ordered list; from set of nodes with no incoming edge, we select the one where following outgoing edges leads to the smallest position in original order.

--- a/src/Mechanic.Tests/Tests.fs
+++ b/src/Mechanic.Tests/Tests.fs
@@ -26,10 +26,31 @@ let correctOrder edges order =
     let orderPos = order |> List.mapi (fun i v -> v, i) |> Map.ofList
     Seq.forall (fun (v,w) -> orderPos.[v] < orderPos.[w]) edges
 
+let checkMinDist nodes edges =
+    let edges = edges |> List.filter (fun (v,w) -> v <> w)
+    let variants = nodes |> List.allPermutations |> List.filter (correctOrder edges)
+    let editDistance order1 order2 =
+        let rec f xs ys =
+            let orderPos1 = xs |> List.mapi (fun i v -> v, i) |> Map.ofList
+            match ys with
+            | [] -> 0
+            | (y::ys) -> orderPos1.[y] + f (xs |> List.filter ((<>)y)) ys
+        f order1 order2
+    match variants with
+    | [] -> ()
+    | _ ->
+    let minOrder = variants |> List.minBy (editDistance nodes)
+    let minDistance = editDistance nodes minOrder
+    printfn "%A" (minOrder, minDistance)
+    match GraphAlg.topologicalOrder nodes edges with
+    | TopologicalOrder order ->
+        Expect.equal (editDistance nodes order) minDistance (sprintf "Not minimal edit distance: original %A result %A min dist %A" nodes order minOrder)
+    | _ -> ()
+
 [<Tests>]
  let tests =
     testList "GraphAlg" [
-        testPropertyWithConfig (Gen.addToConfig {FsCheckConfig.defaultConfig with maxTest = 100; endSize = 100}) "Topological order alg - correctness" <| fun (Gen.RandomGraph(nodes, edges)) ->
+        testPropertyWithConfig (Gen.addToConfig {FsCheckConfig.defaultConfig with maxTest = 100; endSize = 50}) "Topological order alg - correctness" <| fun (Gen.RandomGraph(nodes, edges)) ->
             let rec haveCycleAcc edges acc =
                 let (edgesFrom, edgesRemain) = edges |> List.partition (fun (v,_) -> Set.contains v acc)
                 match edgesFrom with
@@ -45,27 +66,15 @@ let correctOrder edges order =
             | TopologicalOrder order ->
                 Expect.equal (List.length order) (List.length nodes) "Number of nodes differs"
                 let orderPos = order |> List.mapi (fun i v -> v, i) |> Map.ofList
-                Expect.all edges (fun (v,w) -> orderPos.[v] < orderPos.[w]) "Ordering must respect oriented edge"
+                Expect.all edges (fun (v,w) -> orderPos.[v] <= orderPos.[w]) "Ordering must respect oriented edge"
             | Cycle _ -> Expect.isTrue (haveCycle nodes edges) "Cycle reported on graph without cycle"
-
+        
         // this test is really slow for bigger sizes, because it check all permutations of given size
-        testPropertyWithConfig (Gen.addToConfig {FsCheckConfig.defaultConfig with maxTest = 100; endSize = 7}) "Topological order alg - min edit distance" <| fun (Gen.RandomGraph(nodes, edges)) ->
-            let edges = edges |> List.filter (fun (v,w) -> v <> w)
-            let variants = nodes |> List.allPermutations |> List.filter (correctOrder edges)
-            let editDistance order1 order2 =
-                let orderPos1 = order1 |> List.mapi (fun i v -> v, i) |> Map.ofList
-                let rec f i = function
-                    | [] -> 0
-                    | (x::xs) -> orderPos1.[x] - i + f (i+1) xs
-                f 0 order2
-            match variants with
-            | [] -> ()
-            | _ ->
-            let minOrder = variants |> List.minBy (editDistance nodes)
-            let minDistance = editDistance nodes minOrder
-            match GraphAlg.topologicalOrder nodes edges with
-            | TopologicalOrder order ->
-                Expect.equal (editDistance nodes order) minDistance (sprintf "Not minimal edit distance: original %A result %A min dist %A" nodes order minOrder)
-            | _ -> ()
+        testPropertyWithConfig (Gen.addToConfig {FsCheckConfig.defaultConfig with maxTest = 1000; endSize = 7}) "Topological order alg - min edit distance" <| fun (Gen.RandomGraph(nodes, edges)) ->
+            checkMinDist nodes edges
+
+        test "Topological order alg - min edit distance - unit test 1" {
+            checkMinDist [1..7] [7,1;1,2;2,3]
+        }
     ]
 

--- a/src/Mechanic.Tests/Tests.fs
+++ b/src/Mechanic.Tests/Tests.fs
@@ -98,6 +98,7 @@ let checkMinDistSimpleEdit nodes edges =
                 Expect.all edges (fun (v,w) -> orderPos.[v] <= orderPos.[w]) "Ordering must respect oriented edge"
             | Cycle _ -> Expect.isTrue (haveCycle nodes edges) "Cycle reported on graph without cycle"
         
+        // this test is ignored because our alg don't output min dist for all cases
         // this test is really slow for bigger sizes, because it check all permutations of given size
         ptestPropertyWithConfig (Gen.addToConfig {FsCheckConfig.defaultConfig with maxTest = 100; endSize = 7}) "Topological order alg - min edit distance" <| fun (Gen.RandomGraph(nodes, edges)) ->
             checkMinDist nodes edges

--- a/src/Mechanic/GraphAlg.fs
+++ b/src/Mechanic/GraphAlg.fs
@@ -22,12 +22,49 @@ let getMinCycle (nodes: list<_>) edges =
     let edgesMap = edges |> Seq.groupBy fst |> Seq.map (fun (v,g) -> v, g |> Seq.map snd |> Seq.toList) |> Map.ofSeq
     nodes |> List.map (fun v -> getCycleAcc edgesMap [v]) |> choosePick (Seq.minBy (List.length))
 
+let editDistance order1 order2 =
+    let rec f xs ys =
+        let orderPos1 = xs |> List.mapi (fun i v -> v, i) |> Map.ofList
+        match ys with
+        | [] -> 0
+        | (y::ys) -> orderPos1.[y] + f (xs |> List.filter ((<>)y)) ys
+    f order1 order2
+
+let rec fixOrder origOrder edges order =
+    let d = editDistance origOrder order
+    printfn "fixOrder %A" (order, d)
+    let rec move xs (i,j) =
+        if j<i then move (List.rev xs) (j,i) |> List.rev
+        elif i=j then xs
+        else
+        let a = Array.ofList xs
+        let n = a.Length - 1
+        (Array.toList a.[0..i-1]) @ (Array.toList a.[i+1..j]) @ [a.[i]] @ (Array.toList a.[j+1..n])
+
+    [0..(List.length order)-1] |> List.collect (fun i -> [0..(List.length order)-1] |> List.map (fun j -> i,j)) 
+    |> List.map (move order)
+    |> List.filter (fun order -> 
+        let orderPos = order |> List.mapi (fun i v -> v, i) |> Map.ofList
+        edges |> List.exists (fun (v,w) -> orderPos.[w] < orderPos.[v]) |> not)
+    |> List.map (fun x -> d - editDistance origOrder x, x) |> List.filter (fun (d2,_) -> d2 > 0) 
+    |> function
+       | [] -> order
+       | xs -> 
+            xs |> List.maxBy fst |> snd |> fixOrder origOrder edges
+
 let topologicalOrder orderedNodes edges =
+    let edges = edges |> List.filter (fun (v,w) -> v<>w)
     let orderPos = orderedNodes |> List.mapi (fun i v -> v, i) |> Map.ofList
     let nodes = orderedNodes |> set
     let nodeInLevel = edges |> Seq.groupBy snd |> Seq.map (fun (v, xs) -> v, Seq.length xs)
     let initZeroInLevelNodes = nodes - (nodeInLevel |> Seq.map fst |> set)
     let nodeInLevel = Seq.append nodeInLevel (initZeroInLevelNodes |> Seq.map (fun x -> x, 0)) |> Map.ofSeq
+    let orderF i edges v =
+        let rec f v =
+            match edges |> List.filter (fun (x,w) -> x=v && orderPos.[w] < orderPos.[v]) with
+            | [] -> None
+            | xs -> xs |> List.map (fun (_,w) -> (f w |> Option.defaultValue (orderPos.[w], orderPos.[v])) |> Some) |> List.min
+        f v |> Option.map (fun (x, y) -> max (i+1) x, max (i+1) y) |> Option.defaultValue (orderPos.[v], orderPos.[v])
     let rec solve (nodeLevels, edges, acc) =
         let zeroInLevelNodes = nodeLevels |> Map.toSeq |> Seq.filter (fun (_, level) -> level = 0) |> Seq.map fst |> set
         match edges, Set.count zeroInLevelNodes with
@@ -40,7 +77,7 @@ let topologicalOrder orderedNodes edges =
             | None -> failwith ""
         | _ -> 
             let next = 
-                zeroInLevelNodes |> Seq.sortBy (fun n -> orderPos.[n]) |> Seq.map (fun n ->
+                zeroInLevelNodes |> Seq.sortBy (orderF (List.length acc) edges) |> Seq.map (fun n ->
                     let (edges, nodeLevels) =
                         let nodeLevels = nodeLevels |> Map.filter (fun v _ -> v <> n)
                         let (edgesToRemove, remainEdges) = edges |> List.partition (fun (v,_) -> v = n)
@@ -53,6 +90,5 @@ let topologicalOrder orderedNodes edges =
     
     match solve (nodeInLevel, edges, []) with
     | TopologicalOrder result ->
-        let islandNodes = nodes - (set result)
-        TopologicalOrder (Set.toList islandNodes @ result)
+        TopologicalOrder (fixOrder orderedNodes edges result)
     | x -> x

--- a/src/Mechanic/GraphAlg.fs
+++ b/src/Mechanic/GraphAlg.fs
@@ -22,36 +22,6 @@ let getMinCycle (nodes: list<_>) edges =
     let edgesMap = edges |> Seq.groupBy fst |> Seq.map (fun (v,g) -> v, g |> Seq.map snd |> Seq.toList) |> Map.ofSeq
     nodes |> List.map (fun v -> getCycleAcc edgesMap [v]) |> choosePick (Seq.minBy (List.length))
 
-let editDistance order1 order2 =
-    let rec f xs ys =
-        let orderPos1 = xs |> List.mapi (fun i v -> v, i) |> Map.ofList
-        match ys with
-        | [] -> 0
-        | (y::ys) -> orderPos1.[y] + f (xs |> List.filter ((<>)y)) ys
-    f order1 order2
-
-let rec fixOrder origOrder edges order =
-    let d = editDistance origOrder order
-    printfn "fixOrder %A" (order, d)
-    let rec move xs (i,j) =
-        if j<i then move (List.rev xs) (j,i) |> List.rev
-        elif i=j then xs
-        else
-        let a = Array.ofList xs
-        let n = a.Length - 1
-        (Array.toList a.[0..i-1]) @ (Array.toList a.[i+1..j]) @ [a.[i]] @ (Array.toList a.[j+1..n])
-
-    [0..(List.length order)-1] |> List.collect (fun i -> [0..(List.length order)-1] |> List.map (fun j -> i,j)) 
-    |> List.map (move order)
-    |> List.filter (fun order -> 
-        let orderPos = order |> List.mapi (fun i v -> v, i) |> Map.ofList
-        edges |> List.exists (fun (v,w) -> orderPos.[w] < orderPos.[v]) |> not)
-    |> List.map (fun x -> d - editDistance origOrder x, x) |> List.filter (fun (d2,_) -> d2 > 0) 
-    |> function
-       | [] -> order
-       | xs -> 
-            xs |> List.maxBy fst |> snd |> fixOrder origOrder edges
-
 let topologicalOrder orderedNodes edges =
     let edges = edges |> List.filter (fun (v,w) -> v<>w)
     let orderPos = orderedNodes |> List.mapi (fun i v -> v, i) |> Map.ofList
@@ -88,7 +58,4 @@ let topologicalOrder orderedNodes edges =
                 ) |> Seq.tryHead
             next |> Option.map solve |> Option.defaultValue (TopologicalOrder acc)
     
-    match solve (nodeInLevel, edges, []) with
-    | TopologicalOrder result ->
-        TopologicalOrder (fixOrder orderedNodes edges result)
-    | x -> x
+    solve (nodeInLevel, edges, [])


### PR DESCRIPTION
I've found out that my implementation of min-edit distance topological order alg was not correct :(

If anyone want to see non-trivial example of FsCheck property and implementation that are both wrong, I was able to create one :)

After some experimentation, I decided to leave idea of optimal alg. Its quite possible this problem is NP-hard after all, and IMO its not that important for us, alg that is optimal for simple situations - move/add of one file is good enough.

So, I improved ordering heuristics in alg., provided test for simple alterations (change position of one file), and test for min-edit dist optimality is corrected and set to ignore.