### PR TITLE
[Experimental][WIP] Loading external defintions from project references.

### DIFF
--- a/src/Mechanic.CommandLine/Program.fs
+++ b/src/Mechanic.CommandLine/Program.fs
@@ -7,6 +7,8 @@ open Mechanic.Utils
 let main argv =
     match argv.Length with
     | 1 ->
+        SymbolGetter.getExternalDefs (argv.[0])
+        exit 0
         let p = ProjectFile.loadFromFile argv.[0]
         p |> ProjectFile.getSourceFiles
         |> SymbolGraph.solveOrder (fun f -> f.FullName)
@@ -21,4 +23,5 @@ let main argv =
         let pattern = argv.[1]
         SymbolGraph.solveOrderFromPattern root pattern 
         |> printfn "%A"
+    | _ -> ()
     0

--- a/src/Mechanic.CommandLine/Program.fs
+++ b/src/Mechanic.CommandLine/Program.fs
@@ -8,10 +8,9 @@ let main argv =
     match argv.Length with
     | 1 ->
         SymbolGetter.getExternalDefs (argv.[0])
-        exit 0
         let p = ProjectFile.loadFromFile argv.[0]
         p |> ProjectFile.getSourceFiles
-        |> SymbolGraph.solveOrder (fun f -> f.FullName)
+        |> SymbolGraph.solveOrder (fun f -> f.FullName) (argv.[0])
         |> function
             | TopologicalOrderResult.TopologicalOrder xs ->
                 xs |> fun x -> ProjectFile.updateProjectFile x p 

--- a/src/Mechanic.Tests/FileOrderTests.fs
+++ b/src/Mechanic.Tests/FileOrderTests.fs
@@ -30,12 +30,12 @@ let makeTempProject sources =
     tempPath, pf, files
 
 let expectOrder sources =
-    let (_, _, files) = makeTempProject sources
-    Expect.equal (SymbolGraph.solveOrder id files) (TopologicalOrder files) "Wrong order of files"
+    let (_, projFile, files) = makeTempProject sources
+    Expect.equal (SymbolGraph.solveOrder id projFile files) (TopologicalOrder files) "Wrong order of files"
 
 let checkCycle sources =
-    let (_, _, files) = makeTempProject sources
-    match SymbolGraph.solveOrder id files with
+    let (_, projFile, files) = makeTempProject sources
+    match SymbolGraph.solveOrder id projFile files with
     | Cycle _ -> true
     | _ -> false
 
@@ -48,8 +48,8 @@ let expectNotCycle sources =
     |> fun x -> Expect.isFalse x "Dependency cycle not expected"
 
 let expectDependency sources expectedDeps =
-    let (_, _, files) = makeTempProject sources
-    let deps = Mechanic.SymbolGraph.getDependencies files
+    let (_, projFile, files) = makeTempProject sources
+    let deps = Mechanic.SymbolGraph.getDependencies files projFile
     Expect.sequenceEqual 
         (deps |> List.map (fun (a,b,_) -> a,b) |> List.sort) 
         (expectedDeps |> List.map (fun (i,j) -> List.item (i-1) files, List.item (j-1) files) |> List.sort)

--- a/src/Mechanic/AstSymbolCollector.fs
+++ b/src/Mechanic/AstSymbolCollector.fs
@@ -251,6 +251,7 @@ let getOpenDecls (defs: SymbolDef list) (tree: ParsedInput) =
             match d with
             | SynModuleDecl.Open(LongIdentWithDots(lId, _),r) -> 
                 xs <- { OpenName = visitLongIdent lId |> openWithNamespace path; Pos = r.Start; Range = getScope path |> Option.get; IsAutoOpen = false} :: xs
+                xs <- { OpenName = visitLongIdent lId; Pos = r.Start; Range = getScope path |> Option.get; IsAutoOpen = false} :: xs
                 defF d
             | SynModuleDecl.NestedModule(ComponentInfo(_,_,_,lId,_,_,_,_),_,_,_,r) -> 
                 xs <- { OpenName = visitLongIdent lId |> openWithFullNamespace path; Pos = r.Start; Range = r; IsAutoOpen = false } :: xs 

--- a/src/Mechanic/Mechanic.fsproj
+++ b/src/Mechanic/Mechanic.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="SymbolGetter.fs" />
     <Compile Include="SymbolGraph.fs" />
     <Compile Include="Library.fs" />
+  <DotNetCliToolReference Include="dotnet-proj-info" Version="*" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/Mechanic/SymbolGetter.fs
+++ b/src/Mechanic/SymbolGetter.fs
@@ -39,8 +39,9 @@ let getSymbols file =
 
 let getExternalDefs projFile =
     let projFile = (FileInfo projFile).FullName
-    let (_,fscArgs) = Utils.Shell.runCmd "src/Mechanic" "dotnet" (sprintf "proj-info --msbuild-host dotnetmsbuild %s --fsc-args" projFile)
-    printfn "%A" fscArgs
+    Utils.Shell.runCmd "." "dotnet" (sprintf "restore %s" projFile) |> ignore
+    let (_,fscArgs) = Utils.Shell.runCmd "src/Mechanic" "dotnet" (sprintf "proj-info --msbuild-host dotnetmsbuild %s --fsc-args -v" projFile)
+    //printfn "%A" fscArgs
     
     let mkTempFile content =
         let tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".fs")
@@ -50,13 +51,18 @@ let getExternalDefs projFile =
 let foo = 42"""
 
     let fscArgs = (fscArgs |> List.filter (fun l -> not(isNull l) && l.StartsWith("-"))) @ [mkTempFile emptyLibSource]
-    printfn "%A" fscArgs
+    //printfn "%A" fscArgs
     let projOpts = checker.GetProjectOptionsFromCommandLineArgs(projFile, fscArgs |> List.toArray)
     let wholeProjectResults = checker.ParseAndCheckProject(projOpts) |> Async.RunSynchronously
     // printfn "%A" wholeProjectResults.Errors
-    let rec getSymbols entities = 
-        entities
-        |> Seq.collect (fun (e: FSharpEntity) -> [e.TryFullName |> Option.defaultValue e.DisplayName] @ getSymbols e.NestedEntities) |> Seq.toList
-    wholeProjectResults.ProjectContext.GetReferencedAssemblies() |> List.collect (fun a -> getSymbols a.Contents.Entities)
-    |> List.map (fun x -> AstSymbolCollector.Identificator x)
-    //|> List.iter (printfn "%A")
+    let getSymbols entities = 
+        let rec f entities =
+            entities |> Seq.collect (fun (e: FSharpEntity) -> [e] @ Seq.toList (f e.NestedEntities))
+        f entities 
+        |> Seq.filter (fun e -> not e.IsMeasure)
+        |> Seq.map (fun e -> e.TryFullName |> Option.defaultValue e.DisplayName)|> Seq.toList
+    let extDef = 
+        wholeProjectResults.ProjectContext.GetReferencedAssemblies() |> List.collect (fun a -> getSymbols a.Contents.Entities)
+        |> List.map (fun x -> AstSymbolCollector.Identificator x)
+    //extDef |> List.iter (printfn "%A")
+    extDef

--- a/src/Mechanic/SymbolGraph.fs
+++ b/src/Mechanic/SymbolGraph.fs
@@ -5,13 +5,15 @@ open Mechanic.Utils
 open Mechanic.GraphAlg
 open AstSymbolCollector
 
-let getDependencies files =
+let getDependencies files projFile =
     let depsData = files |> List.map (fun (f: string) -> if f.EndsWith ".fs" then SymbolGetter.getSymbols f else f, [], [])
     let autoOpens = depsData |> List.collect (fun (_,_,g) -> g |> List.collect (fun x -> x.Opens |> List.filter (fun o -> o.IsAutoOpen)))
     let depsData = depsData |> List.map (fun (f,defs,opens) -> f, defs, opens |> List.map (fun g -> { g with Opens = g.Opens @ autoOpens }))
+    let externalDefs = SymbolGetter.getExternalDefs projFile
     let allDefsMap = 
-        depsData |> Seq.collect (fun (f,defs,_) -> defs |> List.map (fun d -> Symbol.map lastPart d, (d, f)))
-        |> Seq.groupBy fst |> Seq.map (fun (k, xs) -> k, xs |> Seq.map snd |> Seq.toList) |> Map.ofSeq
+        let defs = depsData |> Seq.collect (fun (f,defs,_) -> defs |> List.map (fun d -> Symbol.map lastPart d, (d, Some f)))
+        let extDefs = externalDefs |> List.map (fun d -> Symbol.map lastPart d, (d, None))
+        Seq.append defs extDefs |> Seq.groupBy fst |> Seq.map (fun (k, xs) -> k, xs |> Seq.map snd |> Seq.toList) |> Map.ofSeq
     let depsData = 
         depsData |> List.map (fun (f,defs,opens) -> 
             f, defs, opens |> List.map (fun o -> 
@@ -37,7 +39,7 @@ let getDependencies files =
                 |> Option.bind (fun g -> 
                     let r = 
                         // try local definitions (from same file) first
-                        opensVariants s |> List.tryPick (fun o -> g |> List.tryFind (fun (d,f) -> o = d && f=f2))
+                        opensVariants s |> List.tryPick (fun o -> g |> List.tryFind (fun (d,f) -> o = d && Option.forall ((=)f2) f))
                         |> Option.orElseWith (fun () -> opensVariants s |> List.tryPick (fun o -> g |> List.tryFind (fun (d,_) -> o = d)))
                     match r with
                     | None -> 
@@ -49,16 +51,16 @@ let getDependencies files =
                 |> Option.map (fun (d,f) -> f, f2, d)
             uses2 |> List.choose tryFindDef
         )
-        |> List.filter (fun (f1,f2,_) -> f1 <> f2) 
+        |> List.choose (fun (f1,f2,x) -> f1 |> Option.bind (fun f1 -> if f1 <> f2 then Some (f1, f2, x) else None))
         |> List.groupBy (fun (f1, f2, _) -> f1, f2) |> List.map (fun ((f1, f2), xs) -> 
             f1, f2, xs |> List.map (fun (_,_,x) -> x) |> List.distinct)
     //printfn "%A" deps
     deps
 
-let solveOrder fileNameSelector xs =
+let solveOrder fileNameSelector projFile xs =
     let filesMap = xs |> Seq.map (fun x -> fileNameSelector x, x) |> Map.ofSeq
     let files = xs |> List.map fileNameSelector
-    let deps = getDependencies files
+    let deps = getDependencies files projFile
     let edges = deps |> List.map (fun (f1,f2,_) -> f1, f2)
     match GraphAlg.topologicalOrder files edges with
     | TopologicalOrderResult.Cycle xs ->
@@ -68,4 +70,4 @@ let solveOrder fileNameSelector xs =
 
 let solveOrderFromPattern root filePattern =
     Directory.EnumerateFiles(root,filePattern) |> Seq.toList
-    |> solveOrder id
+    |> solveOrder id ""


### PR DESCRIPTION
I found out that we need to consider external definitions, because F# allows to override external functions and there is no way to tell if use of that function is external or not (Mechanic output cycle for Paket.Core fsproj because of this).

This is POC of loading external defs that uses direct calls to [`dotnet-proj-info` CLI tool](https://github.com/enricosada/dotnet-proj-info) for getting args for `fsc`. In order for that to work it's needed to invoke Mechanic from root dir.

Of course, best would be to use `dotnet-proj-info` as library. @enricosada any pointers about the best way to do that? Maybe extend `dotnet-proj-info` with library function equivalent of `--fsc-args`?

If anyone would like to help with that, it'd be super-great :)