### PR TITLE
Shuffle-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Advanced usage:
         --pattern <string> <string>
                             Alternative to project file - specify directory and wildcard pattern. Only print out resulting order.
         --dry-run             Don't update project file.
+        --shuffle-test        Do extensive testing of the correctness of Mechanic on given project.
+                              Tries varoius order of source files and check Mechanic result by compiler.
         --log-ast-tree        Print out AST tree for each source file from project.
         --log-collected-symbols
                             Print out collected symbols for each source file from project.

--- a/src/Mechanic.CommandLine/Program.fs
+++ b/src/Mechanic.CommandLine/Program.fs
@@ -9,6 +9,7 @@ type CliArguments =
     | [<MainCommand; Unique>] Project of string
     | Pattern of string * string
     | Dry_Run
+    | Shuffle_Test
     | Log_Ast_Tree
     | Log_Collected_Symbols
     | Log_File_Dependencies
@@ -20,6 +21,7 @@ with
             | Project _ -> "Project file."
             | Pattern _ -> "Alternative to project file - specify directory and wildcard pattern. Only print out resulting order."
             | Dry_Run -> "Don't update project file."
+            | Shuffle_Test -> "Do extensive testing of the correctness of Mechanic on given project."
             | Log_Ast_Tree -> "Print out AST tree for each source file from project."
             | Log_Collected_Symbols -> "Print out collected symbols for each source file from project."
             | Log_File_Dependencies -> "Print out file dependencies in project."
@@ -27,6 +29,8 @@ with
 
 let (|ProjectArg|_|) = (fun (opts: ParseResults<CliArguments>) -> opts.TryGetResult Project)
 let (|PatternArg|_|) = (fun (opts: ParseResults<CliArguments>) -> opts.TryGetResult Pattern)
+let (|ShuffleTestArg|_|) = (fun (opts: ParseResults<CliArguments>) -> 
+    opts.TryGetResult Project |> Option.bind (fun p -> if opts.Contains Shuffle_Test then Some p else None))
 
 [<EntryPoint>]
 let main argv =
@@ -48,6 +52,9 @@ let main argv =
                    FileDependenciesWithSymbols = opts.Contains Log_File_Dependencies_With_Symbols
                 } }
         match opts with
+        | ShuffleTestArg projFile ->
+            let p = ProjectFile.loadFromFile projFile
+            ProjectFile.getSourceFiles p |> SymbolGraph.shuffleTest options (fun f -> f.FullName) projFile |> ignore
         | ProjectArg projFile ->
             let p = ProjectFile.loadFromFile projFile
             p |> ProjectFile.getSourceFiles

--- a/src/Mechanic.CommandLine/Program.fs
+++ b/src/Mechanic.CommandLine/Program.fs
@@ -21,7 +21,8 @@ with
             | Project _ -> "Project file."
             | Pattern _ -> "Alternative to project file - specify directory and wildcard pattern. Only print out resulting order."
             | Dry_Run -> "Don't update project file."
-            | Shuffle_Test -> "Do extensive testing of the correctness of Mechanic on given project."
+            | Shuffle_Test -> "Do extensive testing of the correctness of Mechanic on given project. 
+Tries varoius order of source files and check Mechanic result by compiler."
             | Log_Ast_Tree -> "Print out AST tree for each source file from project."
             | Log_Collected_Symbols -> "Print out collected symbols for each source file from project."
             | Log_File_Dependencies -> "Print out file dependencies in project."

--- a/src/Mechanic/Mechanic.fsproj
+++ b/src/Mechanic/Mechanic.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\paket-files\Microsoft\visualfsharp\src\fsharp\FSharp.Build\Fsc.fs">
+    <Compile Include="../../paket-files/Microsoft/visualfsharp/src/fsharp/FSharp.Build/Fsc.fs">
       <Paket>True</Paket>
       <Link>paket-files/Fsc.fs</Link>
     </Compile>
@@ -17,6 +17,7 @@
     <Compile Include="GraphAlg.fs" />
     <Compile Include="AstSymbolCollector.fs" />
     <Compile Include="ProjectCracker.fs" />
+    <Compile Include="ProjectInfo.fs" />
     <Compile Include="SymbolGetter.fs" />
     <Compile Include="SymbolGraph.fs" />
   </ItemGroup>

--- a/src/Mechanic/ProjectInfo.fs
+++ b/src/Mechanic/ProjectInfo.fs
@@ -1,0 +1,18 @@
+module Mechanic.ProjectInfo
+open Mechanic.Utils
+
+let getFscArgs = memoize <| fun projFile ->
+    let projFile = (System.IO.FileInfo projFile).FullName
+    let runRestore() =
+        let args = (sprintf "restore %s" projFile)
+        let (exitCode, logOut) = Utils.Shell.runCmd "." "dotnet" args
+        if exitCode <> 0 || logOut |> Seq.exists (fun l -> l.Contains "error MSB") then 
+            let msg = (sprintf "\"dotnet %s\" failed (exitCode %i) with output:" args exitCode) :: logOut |> String.concat System.Environment.NewLine
+            failwith msg
+    match projFile with
+    | ProjectCracker.ProjectRecognizer.NetCoreSdk -> runRestore()
+    | _ -> ()
+    
+    let (projOpts,_,_) = ProjectCracker.GetProjectOptionsFromProjectFile projFile
+    let fscArgs = projOpts.OtherOptions |> Seq.toList
+    fscArgs |> List.filter (fun l -> not(isNull l) && l.StartsWith("-"))

--- a/src/Mechanic/SymbolGraph.fs
+++ b/src/Mechanic/SymbolGraph.fs
@@ -78,3 +78,32 @@ let solveOrder (options: Mechanic.Options) fileNameSelector maybeProjFile xs =
 let solveOrderFromPattern options root filePattern =
     Directory.EnumerateFiles(root,filePattern) |> Seq.toList
     |> solveOrder options id None
+
+let shuffleTest (options: Mechanic.Options) fileNameSelector projFile xs =
+    let printSeq label xs =
+        printfn "%s" label
+        xs |> Seq.iter (printfn "%A")
+    let sourceFiles = xs |> Seq.map fileNameSelector
+    if not (Seq.isEmpty (Mechanic.SymbolGetter.checkWithFsc projFile sourceFiles)) then
+        printfn "Original order of project %s is not valid." projFile
+        false
+    else
+    let n = Seq.length xs
+    [0..n-1] |> Seq.forall (fun i ->
+        ([0..i-1] @ [i+1..n-1]) |> List.forall (fun j ->
+            let ys = List.moveItemAtIndexBy i (j-i) xs
+            printfn "Shuffle test: %s moved by %i." (Seq.map fileNameSelector xs |> Seq.item i) (j-i)
+            match solveOrder options fileNameSelector (Some projFile) (Seq.toList ys) with
+            | TopologicalOrderResult.TopologicalOrder result ->
+                let sourceFiles = result |> List.map fileNameSelector
+                let errors = Mechanic.SymbolGetter.checkWithFsc projFile sourceFiles
+                if not (Seq.isEmpty errors) then 
+                    printfn "Mechanic outputs invalid order of project %s:" projFile
+                    printSeq "Tested order:" (Seq.map fileNameSelector ys) 
+                    printSeq "Resulting order:" sourceFiles
+                    printSeq "Errors:" errors
+                    false
+                else true
+            | TopologicalOrderResult.Cycle _ -> true
+        )
+    )

--- a/src/Mechanic/SymbolGraph.fs
+++ b/src/Mechanic/SymbolGraph.fs
@@ -90,9 +90,9 @@ let shuffleTest (options: Mechanic.Options) fileNameSelector projFile xs =
     else
     let n = Seq.length xs
     [0..n-1] |> Seq.forall (fun i ->
-        ([0..i-1] @ [i+1..n-1]) |> List.forall (fun j ->
+        ([i-1..-1..0] @ [i+1..n-1]) |> List.forall (fun j ->
             let ys = List.moveItemAtIndexBy i (j-i) xs
-            printfn "Shuffle test: %s moved by %i." (Seq.map fileNameSelector xs |> Seq.item i) (j-i)
+            printfn "Shuffle test: %s(%i) moved by %i." (Seq.map fileNameSelector xs |> Seq.item i) i (j-i)
             match solveOrder options fileNameSelector (Some projFile) (Seq.toList ys) with
             | TopologicalOrderResult.TopologicalOrder result ->
                 let sourceFiles = result |> List.map fileNameSelector

--- a/src/Mechanic/Utils.fs
+++ b/src/Mechanic/Utils.fs
@@ -1,5 +1,10 @@
 module Mechanic.Utils
 
+let memoize (f: 'a -> 'b) =
+    let cache = System.Collections.Concurrent.ConcurrentDictionary<_, _>(HashIdentity.Structural)
+    fun x ->
+        cache.GetOrAdd(x, lazy (f x)).Force()
+
 module List =
     let rec internal distribute e = function
       | [] -> [[e]]
@@ -8,6 +13,16 @@ module List =
     let rec allPermutations = function
       | [] -> [[]]
       | e::xs -> List.collect (distribute e) (allPermutations xs)
+
+    let swapPairAtIndex i xs =
+        match List.skip i xs with
+        | x :: y :: rest -> (List.take i xs) @ (y :: x :: rest)
+        | rest -> (List.take i xs) @ rest
+
+    let rec moveItemAtIndexBy i n xs =
+        if n > 0 then moveItemAtIndexBy (i+1) (n-1) (swapPairAtIndex i xs)
+        elif n < 0 && i > 0 then moveItemAtIndexBy (i-1) (n+1) (swapPairAtIndex (i-1) xs)
+        else xs
 
 module Namespace =
     let splitByDot (s:string) = 


### PR DESCRIPTION
aka automatic bug report generator :)

When ran with `--shuffle-test`, Mechanic try different input ordering of files in project - for each file it try to move it to each possible position. Result of Mechanic ordering is tested by `fsc`, and error is reported.